### PR TITLE
1.19

### DIFF
--- a/qt/core/browser/input/oxide_qt_input_method_context.cc
+++ b/qt/core/browser/input/oxide_qt_input_method_context.cc
@@ -226,6 +226,20 @@ void InputMethodContext::CancelComposition() {
   im->reset();
 }
 
+void InputMethodContext::Commit() {
+    
+  if (!has_input_method_state_) {
+    return;
+  }
+
+  QInputMethod* im = QGuiApplication::inputMethod();
+  if (!im) {
+    return;
+  }
+
+  im->commit(); 
+}
+
 void InputMethodContext::FocusedNodeChanged() {
   if (!client_) {
     return;

--- a/qt/core/browser/input/oxide_qt_input_method_context.h
+++ b/qt/core/browser/input/oxide_qt_input_method_context.h
@@ -67,6 +67,7 @@ class InputMethodContext : public QObject,
   void SelectionBoundsChanged() override;
   void SelectionChanged() override;
   void CancelComposition() override;
+  void Commit() override;
   void FocusedNodeChanged() override;
 
   InputMethodContextClient* client_; // Owns us

--- a/shared/browser/input/oxide_ime_bridge_impl.cc
+++ b/shared/browser/input/oxide_ime_bridge_impl.cc
@@ -153,9 +153,6 @@ void ImeBridgeImpl::SelectionBoundsChanged(const gfx::Rect& caret_rect,
 }
 
 void ImeBridgeImpl::FocusedNodeChanged(bool is_editable_node) {
-  if (is_editable_node == focused_node_is_editable_) {
-    return;
-  }
 
   focused_node_is_editable_ = is_editable_node;
 

--- a/shared/browser/input/oxide_input_method_context.cc
+++ b/shared/browser/input/oxide_input_method_context.cc
@@ -83,6 +83,7 @@ void InputMethodContext::TextInputStateChanged() {}
 void InputMethodContext::SelectionBoundsChanged() {}
 void InputMethodContext::SelectionChanged() {}
 void InputMethodContext::CancelComposition() {}
+void InputMethodContext::Commit() {}
 void InputMethodContext::FocusedNodeChanged() {}
 
 } // namespace oxide

--- a/shared/browser/input/oxide_input_method_context.h
+++ b/shared/browser/input/oxide_input_method_context.h
@@ -43,6 +43,7 @@ class OXIDE_SHARED_EXPORT InputMethodContext {
   virtual void SelectionBoundsChanged();
   virtual void SelectionChanged();
   virtual void CancelComposition();
+  virtual void Commit();
   virtual void FocusedNodeChanged();
 
  protected:

--- a/shared/browser/oxide_render_widget_host_view.cc
+++ b/shared/browser/oxide_render_widget_host_view.cc
@@ -559,6 +559,12 @@ bool RenderWidgetHostView::HandleGestureForTouchSelection(
     const blink::WebGestureEvent& event) const {
   switch (event.type) {
     case blink::WebInputEvent::GestureLongPress: {
+        
+      // targets https://github.com/ubports/oxide/issues/1
+      if (ime_bridge_.context()) {
+        ime_bridge_.context()->Commit();
+      }
+      
       base::TimeTicks event_time = base::TimeTicks() +
           base::TimeDelta::FromSecondsD(event.timeStampSeconds);
       gfx::PointF location(event.x, event.y);
@@ -569,6 +575,12 @@ bool RenderWidgetHostView::HandleGestureForTouchSelection(
       break;
     }
     case blink::WebInputEvent::GestureTap: {
+      
+      // targets https://github.com/ubports/oxide/issues/1
+      if (ime_bridge_.context()) {
+        ime_bridge_.context()->Commit();
+      }
+        
       gfx::PointF location(event.x, event.y);
       if (selection_controller_->WillHandleTapEvent(
               location, event.data.tap.tapCount)) {


### PR DESCRIPTION
I've found a solution for https://github.com/ubports/oxide/issues/1
It was verified on a BQ Aquaris 4.5 with UT 15.04 OTA-2
[webbrowser-app using oxide 1.19.8 (chromium 55.0.2883.75)]
Of course it should be tested on other devices / by other users as well.

There are 2 modifications: 
(1) for FocusedNodeChanged() the method reset() of the input method is called
(2) for GestureLongPress/GestureTab the method commit() of the input method is called
(https://doc.qt.io/qt-5/qinputmethod.html#commit)